### PR TITLE
fix: swap bl for uint8arraylist

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,11 +117,10 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "bl": "^5.0.0",
-    "it-stream-types": "^1.0.4"
+    "it-stream-types": "^1.0.4",
+    "uint8arraylist": "^1.2.0"
   },
   "devDependencies": {
-    "@types/bl": "^5.0.2",
     "aegir": "^36.1.3",
     "it-all": "^1.0.6",
     "it-pipe": "^2.0.2"


### PR DESCRIPTION
`bl` brings the buffer polyfill, node streams deps and a bunch of
other stuff, and has a big API that we don't really use any of.

Swap for the `uint8arraylist` module which only really concentrates
on appending byte arrays, slicing them and consuming bytes from them.

BREAKING CHANGE: where `BufferList`s were returned, now `Uint8ArrayList`s are