### PR TITLE
fix!: make return type lists instead of copying memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pipe(
   block({ size: 16 }),
   async source => {
     for await (const buf of source) {
-      const str = buf.toString().replace(/[\x00-\x1f]/g, chr)
+      const str = new TextDecoder().decode(buf).replace(/[\x00-\x1f]/g, chr)
       console.log('buf[' + buf.length + ']=' + str)
     }
   }
@@ -70,9 +70,9 @@ import { block } from 'it-block'
 
 ### `const b = block(size, opts)`
 
-Create a new [transform](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#transform-it) `b` that yields chunks of length `size`.
+Create a new [transform](https://www.npmjs.com/package/it-stream-types) `b` that yields chunks of length `size`.
 
-**Note**: chunks that are output are [`BufferList`](https://www.npmjs.com/package/bl) objects NOT `Buffer`s.
+**Note**: chunks that are output are [`Uint8ArrayList`](https://www.npmjs.com/package/uint8arraylist) objects NOT `Uint8Array`s.
 
 When `opts.noPad` is `true`, do not zero-pad the last chunk.
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
   "devDependencies": {
     "aegir": "^37.4.6",
     "it-all": "^1.0.6",
+    "it-map": "^1.0.6",
     "it-pipe": "^2.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ interface Options {
   noPad?: boolean
 }
 
-export function block (size: number, options?: Options): (source: Source<Uint8Array>) => AsyncIterable<Uint8Array> {
-  return async function * (source: Source<Uint8Array>) {
+export function block (size: number, options?: Options): (source: Source<Uint8Array | Uint8ArrayList>) => AsyncIterable<Uint8ArrayList> {
+  return async function * (source: Source<Uint8Array | Uint8ArrayList>) {
     let buffer = new Uint8ArrayList()
     let started = false
 
@@ -16,12 +16,12 @@ export function block (size: number, options?: Options): (source: Source<Uint8Ar
 
       while (buffer.length >= size) {
         if (buffer.length === size) {
-          yield buffer.subarray()
+          yield buffer.sublist()
           buffer = new Uint8ArrayList()
           break
         }
 
-        yield buffer.subarray(0, size)
+        yield buffer.sublist(0, size)
         buffer.consume(size)
       }
     }
@@ -31,7 +31,7 @@ export function block (size: number, options?: Options): (source: Source<Uint8Ar
         buffer.append(new Uint8Array(size - buffer.length))
       }
 
-      yield buffer.subarray()
+      yield buffer.sublist()
     }
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'aegir/chai'
 import { pipe } from 'it-pipe'
 import all from 'it-all'
+import map from 'it-map'
 import { block } from '../src/index.js'
 
 describe('it-block', () => {
@@ -10,6 +11,7 @@ describe('it-block', () => {
     const result = await pipe(
       input,
       block(2),
+      source => map(source, l => l.subarray()),
       async (source) => await all(source)
     )
 
@@ -26,6 +28,7 @@ describe('it-block', () => {
     const result = await pipe(
       input,
       block(4),
+      source => map(source, l => l.subarray()),
       async (source) => await all(source)
     )
 
@@ -41,6 +44,7 @@ describe('it-block', () => {
     const result = await pipe(
       input,
       block(2),
+      source => map(source, l => l.subarray()),
       async (source) => await all(source)
     )
 
@@ -56,6 +60,7 @@ describe('it-block', () => {
     const result = await pipe(
       input,
       block(2, { noPad: true }),
+      source => map(source, l => l.subarray()),
       async (source) => await all(source)
     )
 


### PR DESCRIPTION
Restores previous functionality still alluded to in the readme where
yielded values are no-copy lists instead of copy Uint8Arrays.

BREAKING CHANGE: values yielded from this module are now Uint8ArrayLists