### PR TITLE
fix!: Uint8Arrays are generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
   },
   "dependencies": {
     "it-stream-types": "^2.0.4",
-    "uint8arraylist": "^2.0.0"
+    "uint8arraylist": "^3.0.1",
+    "uint8arrays": "^6.1.0"
   },
   "devDependencies": {
     "aegir": "^48.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import type { Source } from 'it-stream-types'
 import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
+import type { Source } from 'it-stream-types'
 
 interface Options {
   noPad?: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,19 @@
 import { Uint8ArrayList } from 'uint8arraylist'
 import type { Source } from 'it-stream-types'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 
 interface Options {
   noPad?: boolean
 }
 
-export function block (size: number, options?: Options): (source: Source<Uint8Array | Uint8ArrayList>) => AsyncIterable<Uint8ArrayList> {
-  return async function * (source: Source<Uint8Array | Uint8ArrayList>) {
-    let buffer = new Uint8ArrayList()
+export function block <T extends ArrayBufferLike = ArrayBufferLike> (size: number, options?: Options): (source: Source<Uint8Array<T> | Uint8ArrayList<T>>) => AsyncIterable<Uint8ArrayList<ArrayBuffer>> {
+  return async function * (source: Source<Uint8Array<T> | Uint8ArrayList<T>>) {
+    let buffer = new Uint8ArrayList<ArrayBuffer>()
     let started = false
 
     for await (const chunk of source) {
       started = true
-      buffer.append(chunk)
+      buffer.append(withArrayBuffer(chunk instanceof Uint8Array ? chunk : chunk.subarray()))
 
       while (buffer.length >= size) {
         if (buffer.length === size) {


### PR DESCRIPTION
Since microsoft/TypeScript#59417 `Uint8Array`s backed by `ArrayBuffer` are incompatible with those backed with `SharedArrayBuffer` so be explicit about the types returned.

BREAKING CHANGE: the returned `Uint8ArrayList` have a generic type that reflects the internal buffer type